### PR TITLE
Implement block tokenizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+run.py

--- a/dom/dom_builder.py
+++ b/dom/dom_builder.py
@@ -1,0 +1,8 @@
+"""
+Functions for building DOM trees
+"""
+from renderer import DOM
+
+def create_node(type: str, children: list[DOM], text: str) -> DOM:
+    
+

--- a/dom/dom_builder.py
+++ b/dom/dom_builder.py
@@ -1,8 +1,0 @@
-"""
-Functions for building DOM trees
-"""
-from renderer import DOM
-
-def create_node(type: str, children: list[DOM], text: str) -> DOM:
-    
-

--- a/dom/renderer.py
+++ b/dom/renderer.py
@@ -6,33 +6,12 @@ class DOM(object):
     Used to represent a node in an HTML document object model
     """
     element: str
-    children: list['DOM']
+    children: list['DOM' | str]
     text: str
 
-    def __init__(self: 'DOM', element: str, *, children: list['DOM']=[], text: str=""):
+    def __init__(self: 'DOM', element: str, *, children: list['DOM' | str]=[]):
         self.element: str = element
-        self.children: list[DOM] = children
-
-        # The text field is a special case used to contain actual text not html 
-        # For example the text in <p>text</p>. It should be used with the 
-        # element name "text".
-        #
-        # So <p>text</p> would be a DOM object more or less like this: 
-        # (written in json)
-        #   DOM = {
-        #       "element": "p",
-        #       "children": {
-        #           "element": "text",
-        #           "children": [].
-        #           "text": "text"
-        #        }
-        #       "text": ""
-        #   }
-        #
-        # It is implemented this way so that children can be type list['DOM']
-        # rather than list['DOM' | str], as list['DOM' | str] was 
-        # causing problems with the type checker.
-        self.text: str = text
+        self.children: list[DOM | str] = children
 
     def __str__(self):
         return _build_node(self)
@@ -50,10 +29,10 @@ def _build_node(node: DOM) -> str:
 
     html: str = f"<{element}>"
     for next_node in children: 
-        if next_node.element == "text":
-            html += next_node.text
-        else:
-            html += _build_node(next_node)
+        # if next_node is a str then it will be appeneded
+        # if it is a DOM then _build node is called again
+        html = f"{html}{next_node}"
+
     html += f"</{element}>"
 
     return html

--- a/dom/renderer.py
+++ b/dom/renderer.py
@@ -5,6 +5,9 @@ class DOM(object):
     """
     Used to represent a node in an HTML document object model
     """
+    element: str
+    children: list['DOM']
+    text: str
 
     def __init__(self: 'DOM', element: str, *, children: list['DOM']=[], text: str=""):
         self.element: str = element

--- a/parser/tokenizer.py
+++ b/parser/tokenizer.py
@@ -1,0 +1,64 @@
+"""
+Tokenizers for markdownp
+"""
+from io import TextIOBase
+import re
+
+block_spec: tuple[tuple[str, str], ...] = (
+    # blank lines
+    ('[ \\t]*', 'BLANK_LINE'),
+
+    # indented lines
+    ('(?:    +|\t).*', 'INDENT_LINE'),
+
+    # headers
+    (' {0,3}(#{1,6} .+)', 'ATX_HEADER'),
+)
+
+class BlockTokenizer(object):
+    """
+    Lazily returns token based on the block structures of a markdown 
+    document. Each token is equivalent to an entire line in the 
+    markdown file.
+    """
+    def __init__(self, stream: TextIOBase):
+        self._stream = stream
+
+    def _match_line(self, regexp: str, string: str):
+        matched: re.Match[str] | None = re.compile('^' + regexp + '$').match(string)
+
+        if matched == None:
+            return None
+        
+        return matched.group(0)
+
+    def get_next_token(self) -> dict[str, str] | None:
+        # get the next line from the stream
+        next_line: str = self._stream.readline()
+
+        # if there are no more lines in the stream return none
+        if next_line == "":
+            return
+
+        # try to match with each pattern in block_spec
+        for pattern in block_spec:
+            token: str | None = self._match_line(pattern[0], next_line)
+
+            # if there is a match then return it
+            if token != None:
+                if pattern[1] == 'BLANK_LINE':
+                    # no need for value if line is blank
+                    return {
+                        "type": "BLANK_LINE"
+                    }
+                return {
+                    "type": pattern[1],
+                    "value": token
+            }
+
+        # if the line does not meatch any pattern then we just return a normal
+        # text line
+        return {
+                "type": "TEXT_LINE",
+                "value": next_line.strip()
+        }

--- a/parser/tokenizer.py
+++ b/parser/tokenizer.py
@@ -32,13 +32,15 @@ class BlockTokenizer(object):
         
         return matched.group(0)
 
-    def get_next_token(self) -> dict[str, str] | None:
+    def get_next_token(self) -> dict[str, str]:
         # get the next line from the stream
         next_line: str = self._stream.readline()
 
         # if there are no more lines in the stream return none
         if next_line == "":
-            return
+            return {
+                "type": "EOF"
+            }
 
         # try to match with each pattern in block_spec
         for pattern in block_spec:

--- a/parser/tokenizer_tests.py
+++ b/parser/tokenizer_tests.py
@@ -21,10 +21,10 @@ class BlockTokenizerTests(TestCase):
             self.fail("Can only run test with 'block' or 'inline' tokenizer")
         
         for i in range(0, len(expected)):
-            self.assertEquals(expected[i], tokenizer.get_next_token())
+            self.assertEqual(expected[i], tokenizer.get_next_token())
 
         # assert there are no more tokens left
-        self.assertEquals(None, tokenizer.get_next_token())
+        self.assertEqual(None, tokenizer.get_next_token())
 
 
     def test_blank_line(self):

--- a/parser/tokenizer_tests.py
+++ b/parser/tokenizer_tests.py
@@ -1,0 +1,111 @@
+"""
+Unit test cases for markdownp tokenizer
+"""
+from unittest import TestCase, main
+from tokenizer import BlockTokenizer
+from io import StringIO
+
+class BlockTokenizerTests(TestCase):
+    def setup(self):
+        pass
+
+    def run_test(self, text: str, expected: tuple[dict[str,str], ...], tokenizer_type: str = ...):
+        stream: StringIO = StringIO(text)
+
+        if tokenizer_type == 'block':
+            tokenizer = BlockTokenizer(stream)
+        # elif tokenizer_type == 'inline':
+            # TODO put inline tokenizer here
+             # pass
+        else:
+            self.fail("Can only run test with 'block' or 'inline' tokenizer")
+        
+        for i in range(0, len(expected)):
+            self.assertEquals(expected[i], tokenizer.get_next_token())
+
+        # assert there are no more tokens left
+        self.assertEquals(None, tokenizer.get_next_token())
+
+
+    def test_blank_line(self):
+        text: str = "\n"
+        expected: tuple[dict[str, str], ...] = (
+                {"type": "BLANK_LINE"},
+        )
+        self.run_test(text, expected, tokenizer_type='block')
+
+
+        text: str = " \n"
+        expected: tuple[dict[str, str], ...] = (
+                {"type": "BLANK_LINE"},
+        )
+        self.run_test(text, expected, tokenizer_type='block')
+
+        text: str = "\t\n"
+        expected: tuple[dict[str, str], ...] = (
+                {"type": "BLANK_LINE"},
+        )
+        self.run_test(text, expected, tokenizer_type='block')
+
+        text: str = "\t  \t\n\n"
+        expected: tuple[dict[str, str], ...] = (
+                {"type": "BLANK_LINE"},
+                {"type": "BLANK_LINE"},
+        )
+        self.run_test(text, expected, tokenizer_type='block')
+
+    def test_text_line(self):
+        text: str = "hello there"
+        expected: tuple[dict[str, str], ...] = (
+                {"type": "TEXT_LINE", "value": "hello there"},
+        )
+        self.run_test(text, expected, tokenizer_type='block')
+
+        text: str = "hello there\n"
+        expected: tuple[dict[str, str], ...] = (
+                {"type": "TEXT_LINE", "value": "hello there"},
+        )
+        self.run_test(text, expected, tokenizer_type='block')
+        
+        text: str = "hello there\n   Nice to see you"
+        expected: tuple[dict[str, str], ...] = (
+                {"type": "TEXT_LINE", "value": "hello there"},
+                {"type": "TEXT_LINE", "value": "Nice to see you"},
+        )
+        self.run_test(text, expected, tokenizer_type='block')
+
+        text: str = "#hello there\n Tortoise\n"
+        expected: tuple[dict[str, str], ...] = (
+                {"type": "TEXT_LINE", "value": "#hello there"},
+                {"type": "TEXT_LINE", "value": "Tortoise"},
+        )
+        self.run_test(text, expected, tokenizer_type='block')
+
+    def test_atx_header_lines(self):
+        text: str = "## hello there\n"
+        expected: tuple[dict[str, str], ...] = (
+                {"type": "ATX_HEADER", "value": "## hello there"},
+        )
+        self.run_test(text, expected, tokenizer_type='block')
+        
+
+    def test_mixed_lines(self):
+        text: str = "hello there\n\n"
+        expected: tuple[dict[str, str], ...] = (
+                {"type": "TEXT_LINE", "value": "hello there"},
+                {"type": "BLANK_LINE"},
+        )
+        self.run_test(text, expected, tokenizer_type='block')
+
+        text: str = "\nhello there\nanother line    \n\n"
+        expected: tuple[dict[str, str], ...] = (
+                {"type": "BLANK_LINE"},
+                {"type": "TEXT_LINE", "value": "hello there"},
+                {"type": "TEXT_LINE", "value": "another line"},
+                {"type": "BLANK_LINE"},
+        )
+        self.run_test(text, expected, tokenizer_type='block')
+        
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
# Implement Block Tokenizer

The block tokenizer treats every line as a separate token. A line ends in "\r\n", "\r" or "\n".

In this implementation, there are currently four types of tokens. They are as follows:
    
    BLANK_LINE = /^[ \t]+(?:\r\n|\r|\n)$/
    ATX_HEADER = /^ {0,3}#{1,6} .+(?:\r\n|\r|\n)$/
    INDENT_LINE = /^(?: {4,}|\t+)[\s\S]*(?:\r\n|\r|\n)$/
    TEXT_LINE = any line that does not match the above

- Add field declarations to DOM
- Implement tokenizer
- Rework DOM.children to contain both str and DOM
- Return "type": "EOF" instead of None at end of file
- Use assertEqual instead of assertEquals
- Remove dom_builder module
- Ignore run.py
