### PR TITLE
Implement CodeBlock parsing

### DIFF
--- a/parsing/parser.py
+++ b/parsing/parser.py
@@ -66,9 +66,26 @@ class BlockParser(object):
             return
         if self._lookahead["type"] == "ATX_HEADER":
             return self._atx_header()
+        if self._lookahead["type"] == "INDENT_LINE":
+            return self._code_block()
 
         # otherwise treat as a paragraph
         return self._paragraph()
+
+    def _code_block(self) -> DOM:
+        """
+        CodeBlock
+            : INDENT_LINE CodeBlock
+            | INDENT_LINE
+            | None
+            ;
+        """
+        contents: str = self._eat("INDENT_LINE")["value"].strip()
+
+        while self._lookahead["type"] == "INDENT_LINE":
+            contents += f"\n{self._eat('INDENT_LINE')['value'].strip()}"
+
+        return DOM('pre', children=[DOM('code', children=[contents])])
 
     def _atx_header(self) -> DOM:
         """

--- a/parsing/test_parser.py
+++ b/parsing/test_parser.py
@@ -75,6 +75,16 @@ this is a paragraph followed by a header
         expected: str = "<html><p>this is a paragraph followed by a header</p><h2>header number 2</h2></html>"
         self.run_test(markdown, expected)
 
+    def test_code_block(self):
+        markdown: str = """
+    this is a code block
+    this is another part of code 
+    x = a + b
+This is a paragraph
+        """
+        expected: str = "<html><pre><code>this is a code block\nthis is another part of code\nx = a + b</code></pre><p>This is a paragraph</p></html>"
+        self.run_test(markdown, expected)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# Implement CodeBlock parsing

Indented blocks of code are interpreted as a \<pre\> block.
