### PR TITLE
Update Tokenizer

### DIFF
--- a/parsing/tokenizer.py
+++ b/parsing/tokenizer.py
@@ -9,10 +9,17 @@ block_spec: tuple[tuple[str, str], ...] = (
     ('[ \\t]*', 'BLANK_LINE'),
 
     # indented lines
-    ('(?:    +|\t).*', 'INDENT_LINE'),
+    ('(?: {4,}|\t).*', 'INDENT_LINE'),
+
+    # list lines
+    # unordered
+    (' *[-*] .*', 'UL_LINE'),
+
+    # ordered
+    (' *\\d+\\. .*', 'OL_LINE'),
 
     # headers
-    (' {0,3}(#{1,6} .+)', 'ATX_HEADER'),
+    (' *(#{1,6} .+)', 'ATX_HEADER'),
 )
 
 class BlockTokenizer(object):

--- a/parsing/tokenizer.py
+++ b/parsing/tokenizer.py
@@ -5,11 +5,9 @@ from io import TextIOBase
 import re
 
 block_spec: tuple[tuple[str, str], ...] = (
-    # blank lines
-    ('[ \\t]*', 'BLANK_LINE'),
+    # indent
+    ('( {4}|\\t)', 'INDENT'),
 
-    # indented lines
-    ('(?: {4,}|\t).*', 'INDENT_LINE'),
 
     # list lines
     # unordered
@@ -29,45 +27,68 @@ class BlockTokenizer(object):
     markdown file.
     """
     def __init__(self, stream: TextIOBase):
-        self._stream = stream
+        self._stream: TextIOBase = stream
+        self._current_line: str = ""
+        self._cursor: int = 0
 
     def _match_line(self, regexp: str, string: str):
-        matched: re.Match[str] | None = re.compile('^' + regexp + '$').match(string)
+        matched: re.Match[str] | None = re.compile(regexp).match(string, pos=self._cursor)
 
         if matched == None:
             return None
         
-        return matched.group(0)
+        # if there was a match then advance the cursor
+        self._cursor = len(matched.group())
+
+        return matched.group(1)
 
     def get_next_token(self) -> dict[str, str]:
-        # get the next line from the stream
-        next_line: str = self._stream.readline()
+        """
+        Grab the next token off the stream
+        """
+        # lazily load the next line
+        # if the entire current line has been tokenized
+        # subtract 1 from length 1 for the new line at the end
+        if self._cursor >= len(self._current_line) - 1:
+            # get the next line from the stream
+            self._current_line = self._stream.readline()
+            self._cursor = 0 # reset cursor
 
-        # if there are no more lines in the stream return none
-        if next_line == "":
-            return {
-                "type": "EOF"
-            }
+            # if there are no more lines in the stream return EOF
+            if self._current_line == "":
+                return {
+                    "type": "EOF"
+                }
+
+            # check if the line is blank
+            if re.match('^([ \\t]*)$', self._current_line):
+                self._cursor = len(self._current_line)
+                return { "type": "BLANK_LINE" }
 
         # try to match with each pattern in block_spec
         for pattern in block_spec:
-            token: str | None = self._match_line(pattern[0], next_line)
+            token: str | None = self._match_line(pattern[0], self._current_line)
 
             # if there is a match then return it
             if token != None:
-                if pattern[1] == 'BLANK_LINE':
+                if ( pattern[1] == 'INDENT'
+                    or pattern[1] == 'BLOCK'):
                     # no need for value if line is blank
                     return {
-                        "type": "BLANK_LINE"
+                        "type": pattern[1]
                     }
                 return {
                     "type": pattern[1],
-                    "value": token
+                    "value": token.strip()
             }
 
-        # if the line does not meatch any pattern then we just return a normal
+        # if the line does not match any pattern then we just return a normal
         # text line
-        return {
+        # advance the cursor
+        text_line = {
                 "type": "TEXT_LINE",
-                "value": next_line.strip()
+                "value": self._current_line[self._cursor:].strip()
         }
+
+        self._cursor = len(self._current_line)
+        return text_line

--- a/parsing/tokenizer_tests.py
+++ b/parsing/tokenizer_tests.py
@@ -54,6 +54,15 @@ class BlockTokenizerTests(TestCase):
         )
         self.run_test(text, expected, tokenizer_type='block')
 
+    def test_indent(self):
+        text: str = "    indented line"
+        expected: tuple[dict[str, str], ...] = (
+                {"type": "INDENT"},
+                {"type": "TEXT_LINE", "value": "indented line"}
+        )
+        self.run_test(text, expected, tokenizer_type='block')
+
+
     def test_text_line(self):
         text: str = "hello there"
         expected: tuple[dict[str, str], ...] = (
@@ -104,6 +113,14 @@ class BlockTokenizerTests(TestCase):
                 {"type": "TEXT_LINE", "value": "another line"},
                 {"type": "BLANK_LINE"},
         )
+        self.run_test(text, expected, tokenizer_type='block')
+
+        text: str = "this is a line\n\tthis is indented"
+        expected: tuple[dict[str, str], ...] = (
+                {"type": "TEXT_LINE", "value": "this is a line"},
+                {"type": "INDENT"},
+                {"type": "TEXT_LINE", "value": "this is indented"},
+                )
         self.run_test(text, expected, tokenizer_type='block')
         
 


### PR DESCRIPTION
# Tokenizer Rework
This PR reworks the way that the tokenizer handles indented lines, so that they can be rendered correctly in lists.

Previously, each line could only be interpreted as a single token. This way any line that 
began with an indent would be tokenized as INDENT\_LINE. But in a list, indent lines should
be interpreted not just as plain text, but also possibly as other mardown block elements

For example:
    
    - this is a list
        - and this is as well

Should become:
    
    <ul>
        <li>
            <p>This is a list</p>
            <ul>
                <li>
                    <p>and this is as well</p>
                </li>
            </ul>
        </li>
    </ul>

Because of this we have to be able to parse the content within the indented line as though 
it was a normal line.

The solution to this presented here is to split an indented line into two tokens: INDENT and
whatever line comes after it

- Update whitespace handling in tokens
- Create INDENT token
