### PR TITLE
Support multiple indent levels in CodeBlock

### DIFF
--- a/parsing/parser.py
+++ b/parsing/parser.py
@@ -68,6 +68,7 @@ class BlockParser(object):
         Element
             :   AtxHeader
             |   Paragraph
+            |   CodeBlock
             ;
         """
         if self._lookahead["type"] == "BLANK_LINE":

--- a/parsing/test_parser.py
+++ b/parsing/test_parser.py
@@ -38,6 +38,9 @@ this is a paragraph
         expected: str = "<html><p>this is a paragraph\nwith an indented line after it</p></html>"
         self.run_test(markdown, expected)
 
+        markdown: str = "this is a paragraph\twith an indent in the middle"
+        expected: str = "<html><p>this is a paragraph\twith an indent in the middle</p></html>"
+        self.run_test(markdown, expected)
 
     def test_atx_header(self):
         markdown: str = """
@@ -79,10 +82,10 @@ this is a paragraph followed by a header
         markdown: str = """
     this is a code block
     this is another part of code 
-    x = a + b
+        x = a + b
 This is a paragraph
         """
-        expected: str = "<html><pre><code>this is a code block\nthis is another part of code\nx = a + b</code></pre><p>This is a paragraph</p></html>"
+        expected: str = "<html><pre><code>this is a code block</code><code>this is another part of code</code><code>\tx = a + b</code></pre><p>This is a paragraph</p></html>"
         self.run_test(markdown, expected)
 
 

--- a/parsing/tokenizer.py
+++ b/parsing/tokenizer.py
@@ -82,12 +82,16 @@ class BlockTokenizer(object):
 
             # if there is a match then return it
             if token != None:
-                if ( pattern[1] == 'INDENT'
-                    or pattern[1] == 'BLOCK'):
-                    # no need for value if line is blank
+                if pattern[1] == 'INDENT':
                     return {
-                        "type": pattern[1]
+                        "type": pattern[1], 
+                        "value": "\t"
                     }
+                elif pattern[1] == 'BLOCK':
+                    return {
+                        "type": pattern[1],
+                        "value": ""
+                        }
                 return {
                     "type": pattern[1],
                     "value": token.strip()

--- a/parsing/tokenizer.py
+++ b/parsing/tokenizer.py
@@ -36,7 +36,7 @@ class BlockTokenizer(object):
             return None
         
         # if there was a match then advance the cursor
-        self._cursor = len(matched.group())
+        self._cursor += len(matched.group())
 
         return matched.group(1)
 

--- a/parsing/tokenizer.py
+++ b/parsing/tokenizer.py
@@ -48,7 +48,7 @@ class BlockTokenizer(object):
         This is used when a specific structure ignores the token value of a line 
         and just returns a string of plane text. (For example, in a code block)
         """
-        line: str = self._current_line[self._cursor:]
+        line: str = self._current_line[self._cursor:-1] # skip the new line at the end
         self._cursor = len(self._current_line)
         return line
 


### PR DESCRIPTION
This resolves errors in the parsing of CodeBlock segments where there were more than one
initial indents in a line. For example:

    This code block where the following line
        begins with two indents and so it is indented in the \<pre\> block as well

- Update cursor position calculation
- Do not return '\n' from BlockTokenizer.get_rest_of_line
- Include a value for INDENT and BLOCK tokens
- Update documentation
- Add more parser tests
