### PR TITLE
Interpret all tabs as four spaces

### DIFF
--- a/parsing/test_parser.py
+++ b/parsing/test_parser.py
@@ -39,7 +39,7 @@ this is a paragraph
         self.run_test(markdown, expected)
 
         markdown: str = "this is a paragraph\twith an indent in the middle"
-        expected: str = "<html><p>this is a paragraph\twith an indent in the middle</p></html>"
+        expected: str = "<html><p>this is a paragraph    with an indent in the middle</p></html>"
         self.run_test(markdown, expected)
 
     def test_atx_header(self):

--- a/parsing/tokenizer_tests.py
+++ b/parsing/tokenizer_tests.py
@@ -55,13 +55,29 @@ class BlockTokenizerTests(TestCase):
         self.run_test(text, expected, tokenizer_type='block')
 
     def test_indent(self):
-        text: str = "    indented line"
+        text: str = "\tindented line"
         expected: tuple[dict[str, str], ...] = (
                 {"type": "INDENT", "value": "\t"},
                 {"type": "TEXT_LINE", "value": "indented line"}
         )
         self.run_test(text, expected, tokenizer_type='block')
 
+        # double indent
+        text: str = "\t\tindented line"
+        expected: tuple[dict[str, str], ...] = (
+                {"type": "INDENT", "value": "\t"},
+                {"type": "INDENT", "value": "\t"},
+                {"type": "TEXT_LINE", "value": "indented line"}
+        )
+        self.run_test(text, expected, tokenizer_type='block')
+
+        # indent followed by whitespace (less than 4 spaces)
+        text: str = "\t indented line"
+        expected: tuple[dict[str, str], ...] = (
+                {"type": "INDENT", "value": "\t"},
+                {"type": "TEXT_LINE", "value": "indented line"}
+        )
+        self.run_test(text, expected, tokenizer_type='block')
 
     def test_text_line(self):
         text: str = "hello there"
@@ -87,6 +103,13 @@ class BlockTokenizerTests(TestCase):
         expected: tuple[dict[str, str], ...] = (
                 {"type": "TEXT_LINE", "value": "#hello there"},
                 {"type": "TEXT_LINE", "value": "Tortoise"},
+        )
+        self.run_test(text, expected, tokenizer_type='block')
+
+        # line that starts with only three spaces
+        text: str = "   hello there\n"
+        expected: tuple[dict[str, str], ...] = (
+                {"type": "TEXT_LINE", "value": "hello there"},
         )
         self.run_test(text, expected, tokenizer_type='block')
 


### PR DESCRIPTION
# Interpret all tabs as four spaces

All tabs are replaced with four spaces and any whitespace at the
beginning of a line that is not interpreted as an indent will be
ignored.
