### PR TITLE
Implement open-close block parsing

### DIFF
--- a/parsing/test_parser.py
+++ b/parsing/test_parser.py
@@ -27,7 +27,7 @@ And this is the end.
 
 This is a new paragraph, and this is the end of it.
         """
-        expected: str = "<html><p>This is a paragraph.\nAnd this is another part of the paragraph\nAnd this is the end.</p><p>This is a new paragraph, and this is the end of it.</p></html>"
+        expected: str = "<html><body><p>This is a paragraph.\nAnd this is another part of the paragraph\nAnd this is the end.</p><p>This is a new paragraph, and this is the end of it.</p></body></html>"
 
         self.run_test(markdown, expected)
 
@@ -35,24 +35,24 @@ This is a new paragraph, and this is the end of it.
 this is a paragraph
     with an indented line after it
         """
-        expected: str = "<html><p>this is a paragraph\nwith an indented line after it</p></html>"
+        expected: str = "<html><body><p>this is a paragraph\nwith an indented line after it</p></body></html>"
         self.run_test(markdown, expected)
 
         markdown: str = "this is a paragraph\twith an indent in the middle"
-        expected: str = "<html><p>this is a paragraph    with an indent in the middle</p></html>"
+        expected: str = "<html><body><p>this is a paragraph    with an indent in the middle</p></body></html>"
         self.run_test(markdown, expected)
 
     def test_atx_header(self):
         markdown: str = """
 # header number 1
         """
-        expected: str = "<html><h1>header number 1</h1></html>"
+        expected: str = "<html><body><h1>header number 1</h1></body></html>"
         self.run_test(markdown, expected)
 
         markdown: str = """
 ## header number 2
         """
-        expected: str = "<html><h2>header number 2</h2></html>"
+        expected: str = "<html><body><h2>header number 2</h2></body></html>"
         self.run_test(markdown, expected)
 
         markdown: str = """
@@ -61,13 +61,13 @@ this is a paragraph
 ##### header number 5 ##
 ###### header number 6 ###
         """
-        expected: str = "<html><h3>header number 3</h3><h4>header number 4</h4><h5>header number 5</h5><h6>header number 6</h6></html>"
+        expected: str = "<html><body><h3>header number 3</h3><h4>header number 4</h4><h5>header number 5</h5><h6>header number 6</h6></body></html>"
         self.run_test(markdown, expected)
 
         markdown: str = """
 ##this doesn't work
         """
-        expected: str = "<html><p>##this doesn't work</p></html>"
+        expected: str = "<html><body><p>##this doesn't work</p></body></html>"
         self.run_test(markdown, expected)
 
     def test_headers_and_paragraphs(self):
@@ -75,7 +75,7 @@ this is a paragraph
 this is a paragraph followed by a header
 ## header number 2
         """
-        expected: str = "<html><p>this is a paragraph followed by a header</p><h2>header number 2</h2></html>"
+        expected: str = "<html><body><p>this is a paragraph followed by a header</p><h2>header number 2</h2></body></html>"
         self.run_test(markdown, expected)
 
     def test_code_block(self):
@@ -85,7 +85,7 @@ this is a paragraph followed by a header
         x = a + b
 This is a paragraph
         """
-        expected: str = "<html><pre><code>this is a code block</code><code>this is another part of code</code><code>\tx = a + b</code></pre><p>This is a paragraph</p></html>"
+        expected: str = "<html><body><pre><code>this is a code block\nthis is another part of code\n\tx = a + b</code></pre><p>This is a paragraph</p></body></html>"
         self.run_test(markdown, expected)
 
 


### PR DESCRIPTION
The block parser now includes a open_block_stack which will keep track
of which blocks are currently "open" (can have children added). This way
instead of explicitly stating which block to add a child to, the parser
just says to add the child to the lowest open block on the stack.

There were also some changes to the dom structure included:

Separate new CodeBlock lines with '\n' instead of with separate <code>
tags

Wrap all content inside of a <body> tag inside <html>
