### PR TITLE
Update DOM object

### DIFF
--- a/dom/renderer.py
+++ b/dom/renderer.py
@@ -8,12 +8,9 @@ class DOM(object):
     """
     Used to represent a node in an HTML document object model
     """
-    element: str
-    children: list[Union['DOM', str]]
-
     def __init__(self: 'DOM', element: str, *, children: list[Union['DOM', str]]=[]):
         self.element: str = element
-        self.children: list[Union[DOM, str]] = children
+        self.children: list[Union[DOM, str]] = [*children]
 
     def __str__(self):
         return _build_node(self)


### PR DESCRIPTION
Update the DOM object in the following ways:

1. Fix children field list reference error in DOM

   Previously, the default list in the children parameter for the DOM
   constructor was being directly referenced by the DOM.children field. All
   instances that used the default value when they were constructed would
   point to the same list.
   This meant that when an instance was created with this default value and
   then a new value was appended to children, it would change the value of
   the default as well, so new instances would have those same values.

2. Remove static fields from DOM class
